### PR TITLE
fix typo in postinstall for win32

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,6 @@ const url = `https://raw.github.com/imagemin/gif2webp-bin/v${pkg.version}/vendor
 module.exports = new BinWrapper()
 	.src(`${url}macos/gif2webp`, 'darwin')
 	.src(`${url}linux/gif2webp`, 'linux')
-	.src(`${url}win32/gif2webp.exe`, 'win32')
+	.src(`${url}win/gif2webp.exe`, 'win32')
 	.dest(path.resolve(__dirname, '../vendor'))
 	.use(process.platform === 'win32' ? 'gif2webp.exe' : 'gif2webp');


### PR DESCRIPTION
There was a typo in the url to the prebuilt binary for win32.
This fixes #2 for windows at least.